### PR TITLE
Minor changes on data exceed error

### DIFF
--- a/aries_cloudagent/transport/outbound/base.py
+++ b/aries_cloudagent/transport/outbound/base.py
@@ -75,6 +75,10 @@ class OutboundTransportError(TransportError):
     """Generic outbound transport error."""
 
 
+class PushDataSizeExceedError(OutboundTransportError):
+    """Push transport data size exceed error."""
+
+
 class OutboundTransportRegistrationError(OutboundTransportError):
     """Outbound transport registration error."""
 

--- a/aries_cloudagent/transport/outbound/push.py
+++ b/aries_cloudagent/transport/outbound/push.py
@@ -11,7 +11,7 @@ from ...config.injection_context import InjectionContext
 
 from ..stats import StatsTracer
 
-from .base import BaseOutboundTransport, OutboundTransportError
+from .base import BaseOutboundTransport, OutboundTransportError, PushDataSizeExceedError
 
 
 class PushTransport(BaseOutboundTransport):
@@ -60,11 +60,10 @@ class PushTransport(BaseOutboundTransport):
         push_id = endpoint_args.netloc
 
         payload_size = len(payload)
-
-        if(payload_size < 3500):
-            label = context.settings.get(
+        label = context.settings.get(
                 "default_label"
                 )
+        if(payload_size < 3500):
             agent_message = {
                 "Data": {
                             "type": "agent_message",
@@ -85,4 +84,4 @@ class PushTransport(BaseOutboundTransport):
             if result['success'] < 1:
                 raise OutboundTransportError("Push message couldn't be delivered")
         else:
-            raise OutboundTransportError("Data size exceed push notification limits")
+            raise PushDataSizeExceedError("Data size exceed push notification limits")

--- a/aries_cloudagent/transport/outbound/tests/test_push_transport.py
+++ b/aries_cloudagent/transport/outbound/tests/test_push_transport.py
@@ -11,7 +11,7 @@ from aiohttp import web, WSMsgType
 from ....config.injection_context import InjectionContext
 
 from ..push import PushTransport
-from ..base import OutboundTransportError
+from ..base import OutboundTransportError, PushDataSizeExceedError
 
 
 class TestPushTransport(AsyncTestCase):
@@ -52,5 +52,5 @@ class TestPushTransport(AsyncTestCase):
                 endpoint="push://TEST_ID"
             ), 5.0)
             assert self.message_results == [{}]
-        except OutboundTransportError as e:
+        except PushDataSizeExceedError as e:
             assert str(e) == "Data size exceed push notification limits"


### PR DESCRIPTION
New DataSizeExceedError was implemented for throwing when message size exceed the push notification data size limit.