### PR TITLE
Discarding delivered messages in batch pickup

### DIFF
--- a/aries_cloudagent/protocols/pickup/manager.py
+++ b/aries_cloudagent/protocols/pickup/manager.py
@@ -192,7 +192,8 @@ class PickupManager:
 
         records = await PickupMessage.retrieve_by_verkey(self.context, verkey)
 
-        results = [record.serialize() for record in records]
+        undelivered_records = [rec for rec in records if rec.state == PickupMessage.STATE_MESSAGE_WAIT]
+        results = [record.serialize() for record in undelivered_records]
 
         results.sort(key=self.pickup_message_sort)
 
@@ -205,7 +206,7 @@ class PickupManager:
                 message=json.dumps(stored_message.get('message'))
             )
             response.messages_attach.append(pickup_message)
-        return response, records
+        return response, undelivered_records
 
     async def create_status_request(
         self,


### PR DESCRIPTION
Batch pickup request handling changed to deliver only undelivered messages